### PR TITLE
Updates CronJob API version.

### DIFF
--- a/pykube/objects.py
+++ b/pykube/objects.py
@@ -169,7 +169,7 @@ class ConfigMap(NamespacedAPIObject):
 
 class CronJob(NamespacedAPIObject):
 
-    version = "batch/v2alpha1"
+    version = "batch/v1beta1"
     endpoint = "cronjobs"
     kind = "CronJob"
 


### PR DESCRIPTION
As of version >=1.8 of Kubernetes, batch/v1beta1 is the correct API version.